### PR TITLE
Remove ScrollTimeline.fill attribute.

### DIFF
--- a/demo/parallax/index.html
+++ b/demo/parallax/index.html
@@ -177,7 +177,6 @@ function animateParallax() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: header, edge: 'end', clamp: true},
           endScrollOffset: {target: header, clamp: true},
-          fill: 'both',
       })
     });
 }
@@ -191,7 +190,6 @@ function animateZoom() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: container, edge: 'end', threshold: 1, clamp: true},
           endScrollOffset: {target: container, threshold: 1, clamp: true},
-          fill: 'both',
       })
   });
 }
@@ -205,7 +203,6 @@ function animatePan() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: container, edge: 'end', clamp: true},
           endScrollOffset: {target: container, clamp: true},
-          fill: 'both',
       })
   });
 }
@@ -219,7 +216,6 @@ function animateWipe() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: container, edge: 'end', clamp: true},
           endScrollOffset: {target: container, clamp: true},
-          fill: 'both',
       })
   });
 }
@@ -237,7 +233,6 @@ function animateHeaders() {
         timeline: new ScrollTimeline({
             startScrollOffset: {target: headers[i], edge: 'end', rootMargin: '-20px', clamp: true},
             endScrollOffset: {target: headers[i], edge: 'end', threshold: 1, rootMargin: '-20px', clamp: true},
-            fill: 'both',
         })
     });
   }

--- a/demo/parallax/unclamped.html
+++ b/demo/parallax/unclamped.html
@@ -178,7 +178,6 @@ function animateParallax() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: header, edge: 'end'},
           endScrollOffset: {target: header},
-          fill: 'both',
       })
     });
 }
@@ -192,7 +191,6 @@ function animateZoom() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: container, edge: 'end', threshold: 1},
           endScrollOffset: {target: container, threshold: 1},
-          fill: 'both',
       })
   });
 }
@@ -206,7 +204,6 @@ function animatePan() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: container, edge: 'end'},
           endScrollOffset: {target: container},
-          fill: 'both',
       })
   });
 }
@@ -220,7 +217,6 @@ function animateWipe() {
       timeline: new ScrollTimeline({
           startScrollOffset: {target: container, edge: 'end'},
           endScrollOffset: {target: container},
-          fill: 'both',
       })
   });
 }
@@ -238,7 +234,6 @@ function animateHeaders() {
         timeline: new ScrollTimeline({
             startScrollOffset: {target: headers[i], edge: 'end', rootMargin: '-20px'},
             endScrollOffset: {target: headers[i], edge: 'end', threshold: 1, rootMargin: '-20px'},
-            fill: 'both',
         })
     });
   }

--- a/scroll-timeline-base.js
+++ b/scroll-timeline-base.js
@@ -123,7 +123,6 @@ export class ScrollTimeline {
       startScrollOffset: 'auto',
       endScrollOffset: 'auto',
       timeRange: 'auto',
-      fill: 'none',
 
       // Internal members
       animations: [],
@@ -135,7 +134,6 @@ export class ScrollTimeline {
     this.startScrollOffset = options && options.startScrollOffset || 'auto';
     this.endScrollOffset = options && options.endScrollOffset || 'auto';
     this.timeRange = options && options.timeRange || 'auto';
-    this.fill = options && options.fill || 'none';
   }
 
   set scrollSource(element) {
@@ -226,17 +224,11 @@ export class ScrollTimeline {
 
     // Step 3
     if (currentScrollOffset < startOffset) {
-      if (this.fill == 'none' || this.fill == 'forwards')
-        return unresolved;
       return 0;
     }
 
     // Step 4
     if (currentScrollOffset >= endOffset) {
-      if (endOffset < calculateMaxScrollOffset(this.scrollSource, this.orientation) &&
-          (this.fill == 'none' || this.fill == 'backwards')) {
-        return unresolved;
-      }
       return timeRange;
     }
 


### PR DESCRIPTION
Updated based on spec change: [Removed fill from ScrollTimeline](https://github.com/w3c/csswg-drafts/pull/4750):
- Removed fill attribute.
- Return current time of 0 for before start phase and time_range for after end phase.