### PR TITLE
Fix view-timeline-css demo

### DIFF
--- a/demo/view-timeline-css/index.html
+++ b/demo/view-timeline-css/index.html
@@ -55,7 +55,7 @@
     <div class="big-spacer"></div>
     <div id="subject"></div>
     <div class="big-spacer"></div>
+    <div id=box></div>
   </div>
-  <div id=box></div>
 </body>
 


### PR DESCRIPTION
With the scope of view-timelines now properly implemented in https://github.com/flackr/scroll-timeline/pull/83, this demo needs fixing because the target not find a scroll-subject to hook onto.