### PR TITLE
Rename "animation-time-range" -> "animation-range" to match the accepted spec

### DIFF
--- a/demo/view-timeline-css/index.html
+++ b/demo/view-timeline-css/index.html
@@ -25,7 +25,7 @@
   animation-timeline: foo;
   /* Please don't delete the following comments */
   /* This comment has been added to make sure css parser ignores it */
-  /* animation-time-range: enter 0% 100%; */
+  /* animation-range: enter 0% 100%; */
   animation: linear anim;
 }
 
@@ -39,7 +39,7 @@
   width: 50px;
   height: 50px;
   animation-timeline: foo;
-  animation-time-range: enter 0% 100%;
+  animation-range: enter 0% 100%;
   animation: linear anim;
 }
 */

--- a/demo/view-timeline-css/with-delays-using-animation-time-range.html
+++ b/demo/view-timeline-css/with-delays-using-animation-time-range.html
@@ -71,7 +71,7 @@
     background-color: rgba(0, 200, 0, 0.3);
     width: 0px;
 
-    animation-time-range: cover;
+    animation-range: cover;
   }
 
   #progress-bar-progress-b {
@@ -87,7 +87,7 @@
     background-color: rgba(0, 200, 0, 0.3);
     width: 0px;
 
-    animation-time-range: contain;
+    animation-range: contain;
   }
 
   #progress-bar-progress-c {
@@ -103,7 +103,7 @@
     background-color: rgba(0, 200, 0, 0.3);
     width: 0px;
 
-    animation-time-range: enter;
+    animation-range: enter;
   }
 
   #progress-bar-progress-d {
@@ -119,7 +119,7 @@
     background-color: rgba(0, 200, 0, 0.3);
     width: 0px;
 
-    animation-time-range: exit;
+    animation-range: exit;
   }
 
   #progress-bar-progress-e {
@@ -135,7 +135,7 @@
     background-color: rgba(0, 200, 0, 0.3);
     width: 0px;
 
-    animation-time-range: contain 25% 75%;
+    animation-range: contain 25% 75%;
   }
 
   #progress-bar-progress-f {
@@ -151,7 +151,7 @@
     background-color: rgba(0, 200, 0, 0.3);
     width: 0px;
 
-    animation-time-range: enter 150% exit -50%;
+    animation-range: enter 150% exit -50%;
   }
 
   #progress-bar-progress-g {
@@ -168,7 +168,7 @@
     width: 0px;
 
     /* mixed shorthand and longhands */
-    animation-time-range: enter;
+    animation-range: enter;
     animation-delay: cover;
     animation-end-delay: contain;
   }
@@ -187,7 +187,7 @@
     width: 0px;
 
     /* mixed shorthand and longhands */
-    animation-time-range: enter 100% exit 200%;
+    animation-range: enter 100% exit 200%;
     animation-end-delay: contain;
   }
 

--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -1619,7 +1619,7 @@ function defaultAnimationDelay() { return { name: 'cover', offset: CSS.percent(0
 function defaultAnimationEndDelay() { return { name: 'cover', offset: CSS.percent(100) }; }
 
 function parseAnimationDelays(animOptions) {
-  const timeRange = parseTimeRange(animOptions['animation-time-range']);
+  const timeRange = parseTimeRange(animOptions['animation-range']);
 
   if(animOptions['animation-delay'])
     timeRange.start = parseOneAnimationDelay(animOptions['animation-delay'], defaultAnimationDelay().offset);

--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -17,7 +17,7 @@ export const RegexMatcher = {
   ANIMATION_TIMELINE: /animation-timeline\s*:([^;}]+)/,
   ANIMATION_DELAY: /animation-delay\s*:([^;}]+)/,
   ANIMATION_END_DELAY: /animation-end-delay\s*:([^;}]+)/,
-  ANIMATION_TIME_RANGE: /animation-time-range\s*:([^;}]+)/,
+  ANIMATION_TIME_RANGE: /animation-range\s*:([^;}]+)/,
   ANIMATION_NAME: /animation-name\s*:([^;}]+)/,
   ANIMATION: /animation\s*:([^;}]+)/,
   ANONYMOUS_SCROLL: /scroll\(([^)]*)\)/,
@@ -103,7 +103,7 @@ export class StyleParser {
             'animation-timeline': current['animation-timeline'],
             'animation-delay': current['animation-delay'],
             'animation-end-delay': current['animation-end-delay'],
-            'animation-time-range': current['animation-time-range']
+            'animation-range': current['animation-range']
           }
         }
       }
@@ -422,7 +422,7 @@ export class StyleParser {
   saveRelationInList(rule, timelineNames, animationNames) {
     const hasAnimationDelay = rule.block.contents.includes("animation-delay:");
     const hasAnimationEndDelay = rule.block.contents.includes("animation-end-delay:");
-    const hasAnimationTimeRange = rule.block.contents.includes("animation-time-range:");
+    const hasAnimationTimeRange = rule.block.contents.includes("animation-range:");
 
     let animationDelays = [];
     let animationEndDelays = [];
@@ -447,7 +447,7 @@ export class StyleParser {
         ...(animationNames.length ? {'animation-name': animationNames[i % animationNames.length]}: {}),
         ...(animationDelays.length ? {'animation-delay': animationDelays[i % animationDelays.length]}: {}),
         ...(animationEndDelays.length ? {'animation-end-delay': animationEndDelays[i % animationEndDelays.length]}: {}),
-        ...(animationTimeRanges.length ? {'animation-time-range': animationTimeRanges[i % animationTimeRanges.length]}: {}),
+        ...(animationTimeRanges.length ? {'animation-range': animationTimeRanges[i % animationTimeRanges.length]}: {}),
       });
     }
   }


### PR DESCRIPTION
**TL;DR**
Rename "animation-time-range" to "animation-range" because this is the latest spec (according to [this](https://github.com/flackr/scroll-timeline/issues/64#issuecomment-1544020128) comment).

**WHY**
At the moment polyfill implementation diverged from the latest spec.
That means we can't produce tutorials or educational materials that show use of the latest (accepted) spec because the polyfill itself is not up-to-date with the latest spec.

This PR brings the polyfill a little bit closer to the current version of the spec.

@bramus @flackr @kevers-google My apologies for poking you like this directly in this PR. I am not sure how else to draw attention to this 😀