### PR TITLE
Fix axis names

### DIFF
--- a/src/intersection-based-offset.js
+++ b/src/intersection-based-offset.js
@@ -145,8 +145,8 @@ function resolveLength(length, containerSize) {
 
 export function calculateOffset(source, axis, offset, startOrEnd) {
   // TODO: Support other writing directions.
-  if (axis == "block") axis = "vertical";
-  else if (axis == "inline") axis = "horizontal";
+  if (axis == "block") axis = "y";
+  else if (axis == "inline") axis = "x";
   let originalViewport =
     source == document.scrollingElement
       ? {
@@ -193,7 +193,7 @@ export function calculateOffset(source, axis, offset, startOrEnd) {
   // Invert threshold for start position.
   if (offset.edge == "start") threshold = 1 - threshold;
   // Projected point into the scroller scroll range.
-  if (axis == "vertical") {
+  if (axis == "y") {
     let point =
       target.top +
       target.height * threshold -
@@ -207,7 +207,7 @@ export function calculateOffset(source, axis, offset, startOrEnd) {
       return point;
     }
   } else {
-    // axis == 'horizontal'
+    // axis == 'x'
     let point =
       target.left +
       target.width * threshold -

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -60,7 +60,7 @@ function directionAwareScrollOffset(source, axis) {
   // http://drafts.csswg.org/css-writing-modes-4/#block-flow
   const horizontalWritingMode = style.writingMode == 'horizontal-tb';
   let currentScrollOffset  = source.scrollTop;
-  if (axis == 'horizontal' ||
+  if (axis == 'x' ||
      (axis == 'inline' && horizontalWritingMode) ||
      (axis == 'block' && !horizontalWritingMode)) {
     // Negative values are reported for scrollLeft when the inline text
@@ -95,12 +95,12 @@ export function calculateMaxScrollOffset(source, axis) {
   const horizontalWritingMode =
     getComputedStyle(source).writingMode == 'horizontal-tb';
   if (axis === "block")
-    axis = horizontalWritingMode ? "vertical" : "horizontal";
+    axis = horizontalWritingMode ? "y" : "x";
   else if (axis === "inline")
-    axis = horizontalWritingMode ? "horizontal" : "vertical";
-  if (axis === "vertical")
+    axis = horizontalWritingMode ? "x" : "y";
+  if (axis === "y")
     return source.scrollHeight - source.clientHeight;
-  else if (axis === "horizontal")
+  else if (axis === "x")
     return source.scrollWidth - source.clientWidth;
 }
 
@@ -251,7 +251,7 @@ export class ScrollTimeline {
 
   set axis(axis) {
     if (
-      ["block", "inline", "horizontal", "vertical", "x", "y"].indexOf(axis) === -1
+      ["block", "inline", "x", "y"].indexOf(axis) === -1
     ) {
       throw TypeError("Invalid axis");
     }
@@ -460,7 +460,7 @@ export function calculateRange(phase, container, target, axis, optionsInset) {
   let viewSize = undefined;
   let viewPos = undefined;
   let containerSize = undefined;
-  if (axis == 'horizontal' ||
+  if (axis == 'x' ||
       (axis == 'inline' && horizontalWritingMode) ||
       (axis == 'block' && !horizontalWritingMode)) {
     viewSize = target.clientWidth;

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -220,7 +220,7 @@ export class ScrollTimeline {
   constructor(options) {
     scrollTimelineOptions.set(this, {
       source: null,
-      axis: "block",
+      axis: (options && options.axis) ? options.axis : 'block',
       anonymousSource: (options ? options.anonymousSource : null),
       anonymousTarget: (options ? options.anonymousTarget : null),
 
@@ -236,7 +236,6 @@ export class ScrollTimeline {
       options && options.source !== undefined ? options.source
                                               : document.scrollingElement;
     updateSource(this, source);
-    this.axis = (options && options.axis) || "block";
     updateInternal(this);
   }
 

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -595,11 +595,6 @@ export class ViewTimeline extends ScrollTimeline {
   // ViewTimelineOptions. Inferring the source from the subject if not
   // explicitly set.
   constructor(options) {
-    if (options.axis) {
-      // Orientation called axis for a view timeline. Internally we can still
-      // call this axis, since the internal naming is not exposed.
-      options.axis = options.axis;
-    }
     super(options);
     const details = scrollTimelineOptions.get(this);
     details.subject = options && options.subject ? options.subject : undefined;

--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -35,7 +35,7 @@ const ANIMATION_KEYWORDS = [
   'ease', 'linear', 'ease-in', 'ease-out', 'ease-in-out'
 ];
 
-const TIMELINE_AXIS_TYPES = ['block', 'inline',  'vertical', 'horizontal'];
+const TIMELINE_AXIS_TYPES = ['block', 'inline', 'x', 'y'];
 const ANONYMOUS_TIMELINE_SOURCE_TYPES = ['nearest', 'root'];
 
 // 1 - Extracts @scroll-timeline and saves it in scrollTimelineOptions.
@@ -341,8 +341,11 @@ export class StyleParser {
 
     let axes = [];
     if(hasScrollTimelineAxis) {
-      axes = this.extractMatches(rule.block.contents, RegexMatcher.SCROLL_TIMELINE_AXIS);
-      axes = axes.filter(a => TIMELINE_AXIS_TYPES.includes(a));
+      const extractedAxes = this.extractMatches(rule.block.contents, RegexMatcher.SCROLL_TIMELINE_AXIS);
+      axes = extractedAxes.filter(a => TIMELINE_AXIS_TYPES.includes(a));
+      if (axes.length != extractedAxes.length) {
+        throw new Error('Invalid axis');
+      }
     }
 
     for(let i = 0; i < timelines.length; i++) {
@@ -400,8 +403,11 @@ export class StyleParser {
       insets = this.extractMatches(rule.block.contents, RegexMatcher.VIEW_TIMELINE_INSET);
 
     if(hasViewTimelineAxis) {
-      axes = this.extractMatches(rule.block.contents, RegexMatcher.VIEW_TIMELINE_AXIS);
-      axes = axes.filter(a => TIMELINE_AXIS_TYPES.includes(a));
+      const extractedAxes = this.extractMatches(rule.block.contents, RegexMatcher.VIEW_TIMELINE_AXIS);
+      axes = extractedAxes.filter(a => TIMELINE_AXIS_TYPES.includes(a));
+      if (axes.length != extractedAxes.length) {
+        throw new Error('Invalid axis');
+      }
     }
 
     for(let i = 0; i < timelines.length; i++) {


### PR DESCRIPTION
The values `horizontal` and `vertical` are no longer valid as per recent spec change. They have been replaced by the values `x` and `y` respectively. This PR lands that rename, while also fixing a bug along the way.

With this PR applied, the demo at `/demo/parallax/` starts working correctly again upon switching the mode to either “Horizontal left to right” or “Horizontal right to left”.