### PR TITLE
Declare `parts` variable before using it

### DIFF
--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -327,7 +327,7 @@ export class StyleParser {
     if(hasScrollTimeline) {
       const scrollTimelines = this.extractMatches(rule.block.contents, RegexMatcher.SCROLL_TIMELINE);
       for(const st of scrollTimelines) {
-        parts = this.split(st);
+        const parts = this.split(st);
         let options = {selector: rule.selector, name: ''};
 
         if(parts.length == 1) {
@@ -386,7 +386,7 @@ export class StyleParser {
     if(hasViewTimeline) {
       const viewTimelines = this.extractMatches(rule.block.contents, RegexMatcher.VIEW_TIMELINE);
       for(let tl of viewTimelines) {
-        parts = this.split(tl);
+        const parts = this.split(tl);
         let options = {selector: rule.selector, name: '', inset: null};
         if(parts.length == 1) {
           options.name = parts[0];


### PR DESCRIPTION
In JavaScript Strict Mode, all variables need to be declared. Fixes #119.