### PR TITLE
Return the default rangeOffset when no value is given

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -1601,8 +1601,7 @@ export class ProxyAnimation {
 // Parses an individual TimelineRangeOffset
 // TODO: Support all formatting options
 function parseTimelineRangeOffset(value, defaultValue) {
-  // TODO: Should this return the default value?
-  if(!value) return null;
+  if(!value) return defaultValue;
 
   // Extract parts from the passed in value.
   let { rangeName, offset } = defaultValue;


### PR DESCRIPTION
When no range information is passed in via the Animation’s `options`, demos such as the one in https://github.com/flackr/scroll-timeline/issues/119#issuecomment-1658247473 would throw an error: `TypeError: null is not an object (evaluating 'n.rangeName')`.

This PR makes sure that the default rangeOffset value is used when none is given.