### PR TITLE
Add missing parseError function

### DIFF
--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -766,6 +766,10 @@ export class StyleParser {
     }
   }
 
+  parseError(p, msg) {
+    return Error(`(${p.name ? p.name : '<anonymous file>'}): ${msg}`);
+  }
+
   eatUntil(s, p, replaceWithSpace=false) {
     const startIndex = p.index;
     while (!this.lookAhead(s, p)) {


### PR DESCRIPTION
This `parseError` method is called in the CSS parser but is nowhere to be found. This PR fixes this.

The function is adapted from https://github.com/GoogleChromeLabs/container-query-polyfill/blob/faf2600f7cd7b16e500f40676dd1b144005bd186/src/engine.ts#L418, which formed the basis of the CSS Parser used in the scroll-timeline polyfill.