### PR TITLE
Improve WPT Score

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -220,7 +220,7 @@ export class ScrollTimeline {
   constructor(options) {
     scrollTimelineOptions.set(this, {
       source: null,
-      axis: (options && options.axis) ? options.axis : 'block',
+      axis: null,
       anonymousSource: (options ? options.anonymousSource : null),
       anonymousTarget: (options ? options.anonymousTarget : null),
 
@@ -236,6 +236,10 @@ export class ScrollTimeline {
       options && options.source !== undefined ? options.source
                                               : document.scrollingElement;
     updateSource(this, source);
+
+    const axis = (options && options.axis) ? options.axis : 'block';
+    this.axis = axis;
+
     updateInternal(this);
   }
 


### PR DESCRIPTION
This PR ensures that the `axis` value gets checked when creating a new `ScrollTimeline` instance.

With this adjustment the _“Creating a ScrollTimeline with an invalid axis value should throw”_ test in `/scroll-animations/scroll-timelines/constructor.html` now passes.