### PR TITLE
Remove old/unused code

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -15,11 +15,9 @@
 import { installCSSOM } from "./proxy-cssom.js";
 installCSSOM();
 
-const AUTO = new CSSKeywordValue("auto");
 const DEFAULT_TIMELINE_AXIS = 'block';
 
 let scrollTimelineOptions = new WeakMap();
-let extensionScrollOffsetFunctions = [];
 
 function scrollEventSource(source) {
   if (source === document.scrollingElement) return document;

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { parseLength } from "./utils";
-
 import { installCSSOM } from "./proxy-cssom.js";
 installCSSOM();
 

--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -37,8 +37,8 @@ const ANIMATION_KEYWORDS = [
 const TIMELINE_AXIS_TYPES = ['block', 'inline', 'x', 'y'];
 const ANONYMOUS_TIMELINE_SOURCE_TYPES = ['nearest', 'root'];
 
-// 1 - Extracts @scroll-timeline and saves it in scrollTimelineOptions.
-// 2 - If we find any animation-timeline in any of the CSS Rules, 
+// Parse a styleSheet to extract the relevant elements needed for
+// scroll-driven animations.
 // we will save objects in a list named cssRulesWithTimelineName
 export class StyleParser {
   constructor() {
@@ -55,8 +55,8 @@ export class StyleParser {
   // https://drafts.csswg.org/css-syntax/#parser-diagrams
   // https://github.com/GoogleChromeLabs/container-query-polyfill/blob/main/src/engine.ts
   // This function is called twice, in the first pass we are interested in saving
-  // @scroll-timeline and @keyframe names, in the second pass
-  // we will parse other rules
+  // the @keyframe names, in the second pass we will parse other rules to extract
+  // scroll-animations related properties and values.
   transpileStyleSheet(sheetSrc, firstPass, srcUrl) {
     // AdhocParser
     const p = {
@@ -196,41 +196,6 @@ export class StyleParser {
     }
 
     return null;
-  }
-
-  parseScrollTimeline(p) {
-    const startIndex = p.index;
-    this.assertString(p, "@scroll-timeline");
-    this.eatWhitespace(p);
-    let name = this.parseIdentifier(p);
-    this.eatWhitespace(p);
-    this.assertString(p, "{"); // eats {
-    this.eatWhitespace(p);
-
-    let scrollTimeline = {
-      name: name,
-      source: "auto",
-      axis: undefined,
-    };
-
-    while (this.peek(p) !== "}") {
-      const property = this.parseIdentifier(p);
-      this.eatWhitespace(p);
-      this.assertString(p, ":");
-      this.eatWhitespace(p);
-      scrollTimeline[property] = this.removeEnclosingDoubleQuotes(this.eatUntil(";", p));
-      this.assertString(p, ";");
-      this.eatWhitespace(p);
-    }
-
-    this.assertString(p, "}");
-    const endIndex = p.index;
-    this.eatWhitespace(p);
-    return {
-      scrollTimeline,
-      startIndex,
-      endIndex,
-    };
   }
 
   handleScrollTimelineProps(rule, p) {

--- a/src/scroll-timeline-css.js
+++ b/src/scroll-timeline-css.js
@@ -57,14 +57,6 @@ function relativePosition(phase, container, target, axis, optionsInset, percent)
   return calculateRelativePosition(phaseRange, percent, coverRange);
 }
 
-function isDescendant(child, parent) {
-  while (child) {
-    if (child == parent) return true;
-    child = child.parentNode;
-  }
-  return false;
-}
-
 function createScrollTimeline(anim, animationName, target) {
   const animOptions = parser.getAnimationTimelineOptions(animationName, target);
 

--- a/src/scroll-timeline-css.js
+++ b/src/scroll-timeline-css.js
@@ -1,4 +1,4 @@
-import { StyleParser, RegexMatcher } from "./scroll-timeline-css-parser";
+import { StyleParser } from "./scroll-timeline-css-parser";
 import { ProxyAnimation } from "./proxy-animation"
 import { ScrollTimeline, ViewTimeline, getScrollParent, calculateRange,
   calculateRelativePosition } from "./scroll-timeline-base";


### PR DESCRIPTION
Some minor code cleanups but also two bigger ones:

- fce08c1a83f779794d5e15e0d7f1984fcb145379 Remove old `@scroll-timeline` parsing logic
- 453fdf4ed324bfe7d4769cc4557ff289635aabd4 Remove code that tries to extract the `animation-timeline` from the `animation` shorthand