### PR TITLE
Add `entry-crossing` and `exit-crossing` ranges

### DIFF
--- a/demo/view-timeline/index.html
+++ b/demo/view-timeline/index.html
@@ -59,10 +59,20 @@
     width:  90%;
   }
 
+  #target.taller {
+    height: 650px;
+  }
+
   #container.rtl > #target,
   #container.ltr > #target {
     height:  90%;
     width: 125px;
+  }
+
+  #container.rtl > #target.taller,
+  #container.ltr > #target.taller {
+    height:  90%;
+    width: 650px;
   }
 
   .progress-bar,
@@ -104,24 +114,32 @@
     <div class="progress-bar" style="top: 270px">
       <span>entry 150% exit -50%</span>
     </div>
+    <div class="progress-bar" style="top: 320px;"><span>entry-crossing</span></div>
+    <div class="progress-bar" style="top: 370px;"><span>exit-crossing</span></div>
     <div class="progress-bar-progress" style="top: 20px;"></div>
     <div class="progress-bar-progress" style="top: 70px;"></div>
     <div class="progress-bar-progress" style="top: 120px;"></div>
     <div class="progress-bar-progress" style="top: 170px;"></div>
     <div class="progress-bar-progress" style="top: 220px;"></div>
     <div class="progress-bar-progress" style="top: 270px;"></div>
+    <div class="progress-bar-progress" style="top: 320px;"></div>
+    <div class="progress-bar-progress" style="top: 370px;"></div>
   </div>
   <input type="radio" name="layout" id="vertical-tb" checked>
-  <label for="vertical">Vertical top to bottom</label>
+  <label for="vertical-tb">Vertical top to bottom</label>
   <input type="radio" name="layout" id="horizontal-ltr">
-  <label for="horizontal-rtl">Horizontal left to right</label>
+  <label for="horizontal-ltr">Horizontal left to right</label>
   <input type="radio" name="layout" id="horizontal-rtl">
   <label for="horizontal-rtl">Horizontal right to left</label>
+  <br>
+  <input type="checkbox" name="subject-size" id="taller-than-scrollport-subject">
+  <label for="taller-than-scrollport-subject">Taller than scrollport subject</label>
 </body>
 <script src="../../dist/scroll-timeline.js"></script>
 <script type="text/javascript">
   "use strict";
 
+  let layout = 'vertical-tb';
   const progressBars = document.querySelectorAll('.progress-bar-progress');
   const createProgressAnimation = (bar, rangeStart, rangeEnd, axis) => {
     const target = document.getElementById('target');
@@ -136,8 +154,8 @@
       fill: 'both'
     });
   }
-  const createAnimations = (selection) => {
-    const axis = selection == 'vertical-tb' ? 'block' : 'inline';
+  const createAnimations = (layout) => {
+    const axis = layout == 'vertical-tb' ? 'block' : 'inline';
     document.getAnimations().forEach(anim => {
       anim.cancel();
     });
@@ -148,6 +166,8 @@
     createProgressAnimation(progressBars[4], 'contain 25%', 'contain 75%', axis);
     createProgressAnimation(progressBars[5], 'entry 150%', 'exit -50%',
                             axis);
+    createProgressAnimation(progressBars[6], 'entry-crossing', 'entry-crossing', axis);
+    createProgressAnimation(progressBars[7], 'exit-crossing', 'exit-crossing', axis);
   };
 
   document.querySelectorAll('input').forEach(input => {
@@ -155,26 +175,41 @@
       document.getAnimations().forEach(anim => {
         anim.cancel();
       });
-      const selection = event.target.id;
-      switch(selection) {
-        case 'vertical-tb':
-          container.classList.remove('rtl');
-          container.classList.remove('ltr');
-          overlay.classList.remove('rtl');
+
+      switch (event.target.name) {
+        case 'layout':
+          const selection = event.target.id;
+          switch(selection) {
+            case 'vertical-tb':
+              container.classList.remove('rtl');
+              container.classList.remove('ltr');
+              overlay.classList.remove('rtl');
+              break;
+
+            case 'horizontal-ltr':
+              container.classList.remove('rtl');
+              container.classList.add('ltr');
+              overlay.classList.remove('rtl');
+              break;
+
+            case 'horizontal-rtl':
+              container.classList.add('rtl');
+              container.classList.remove('ltr');
+              overlay.classList.add('rtl');
+          }
+          layout = selection;
           break;
 
-        case 'horizontal-ltr':
-          container.classList.remove('rtl');
-          container.classList.add('ltr');
-          overlay.classList.remove('rtl');
+        case 'subject-size':
+          if(event.target.checked) {
+            target.classList.add('taller');
+          } else {
+            target.classList.remove('taller');
+          }
           break;
-
-        case 'horizontal-rtl':
-          container.classList.add('rtl');
-          container.classList.remove('ltr');
-          overlay.classList.add('rtl');
       }
-      createAnimations(evt.target.id);
+
+      createAnimations(layout);
     });
   });
 

--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -8,7 +8,7 @@ import {
 const nativeElementAnimate = window.Element.prototype.animate;
 const nativeAnimation = window.Animation;
 
-export const ANIMATION_RANGE_NAMES = ['entry', 'exit', 'cover', 'contain'];
+export const ANIMATION_RANGE_NAMES = ['entry', 'exit', 'cover', 'contain', 'entry-crossing', 'exit-crossing'];
 
 class PromiseWrapper {
   constructor() {

--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -704,6 +704,15 @@ function createProxyEffect(details) {
              ? (totalDuration - timing.delay - timing.endDelay) /
                  timing.iterations
              : 0;
+          // When the rangeStart comes after the rangeEnd, we end up in a situation
+          // that cannot work. We can tell this by having ended up with a negative
+          // duration. In that case, we need to adjust the computed timings. We do
+          // this by setting the duration to 0 and then assigning the remainder of
+          // the totalDuration to the endDelay
+          if (timing.duration < 0) {
+            timing.duration = 0;
+            timing.endDelay = totalDuration - timing.delay;
+          }
           // Set the timing on the native animation to the normalized values
           // while preserving the specified timing.
           nativeUpdateTiming.apply(effect, [timing]);

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -506,6 +506,7 @@ export function calculateRange(phase, container, target, axis, optionsInset) {
 
   let startOffset = undefined;
   let endOffset = undefined;
+  let targetIsTallerThanContainer = viewSize > containerSize ? true : false;
 
   switch(phase) {
     case 'cover':
@@ -525,6 +526,16 @@ export function calculateRange(phase, container, target, axis, optionsInset) {
 
     case 'exit':
       startOffset = containEndOffset;
+      endOffset = coverEndOffset;
+      break;
+
+    case 'entry-crossing':
+      startOffset = coverStartOffset;
+      endOffset = targetIsTallerThanContainer ? containEndOffset : containStartOffset;
+      break;
+
+    case 'exit-crossing':
+      startOffset = targetIsTallerThanContainer ? containStartOffset : containEndOffset;
       endOffset = coverEndOffset;
       break;
   }


### PR DESCRIPTION
These two ranges are missing from the polyfill. This PR fixes that.

Also included is a fix to cater for scenarios where the defined `rangeStart` comes after the `rangeEnd`. This was surfaced with the view-timeline demo that uses `entry 150% exit -50%` as the range. For the taller than scrollport scenario, the `rangeEnd` comes before the `rangeStart`. I looked at what Blink does for this, and there it seems that it respects the `rangeStart` and immediately flips to the end frame when passing that offset. This behavior is no mimicked by the polyfill.