### PR TITLE
Correctly handle already finished ViewTransition animations upon load

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -313,7 +313,7 @@ function updateFinishedState(details, didSeek, synchronouslyNotify) {
     const playbackRate = effectivePlaybackRate(details);
     const upperBound = effectEnd(details);
     let boundary = details.previousCurrentTime;
-    if (playbackRate > 0 && unconstrainedCurrentTime >= upperBound) {
+    if (playbackRate > 0 && unconstrainedCurrentTime >= upperBound && details.previousCurrentTime != null) {
       if (boundary === null || boundary < upperBound)
         boundary = upperBound;
       details.holdTime = didSeek ? unconstrainedCurrentTime : boundary;

--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -313,7 +313,8 @@ function updateFinishedState(details, didSeek, synchronouslyNotify) {
     const playbackRate = effectivePlaybackRate(details);
     const upperBound = effectEnd(details);
     let boundary = details.previousCurrentTime;
-    if (playbackRate > 0 && unconstrainedCurrentTime >= upperBound && details.previousCurrentTime != null) {
+    if (playbackRate > 0 && unconstrainedCurrentTime >= upperBound &&
+        details.previousCurrentTime != null) {
       if (boundary === null || boundary < upperBound)
         boundary = upperBound;
       details.holdTime = didSeek ? unconstrainedCurrentTime : boundary;


### PR DESCRIPTION
Fixes #144. 

See https://github.com/flackr/scroll-timeline/issues/144#issuecomment-1697705355 and https://github.com/flackr/scroll-timeline/issues/144#issuecomment-1697942416 for details.

Here’s a before and after recording:

- Without Fix:

  https://github.com/flackr/scroll-timeline/assets/213073/d0b49e0a-89e1-4330-94e9-b7a203c6d564

- With Fix:

  https://github.com/flackr/scroll-timeline/assets/213073/00fa694d-87d7-4a79-ba63-d0b1dfdd6291







