### PR TITLE
Workaround for Safari’s BFCache not playing nice with the polyfill

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -197,6 +197,11 @@ export function removeAnimation(scrollTimeline, animation) {
 export function addAnimation(scrollTimeline, animation, tickAnimation) {
   let animations = scrollTimelineOptions.get(scrollTimeline).animations;
   for (let i = 0; i < animations.length; i++) {
+    // @TODO: This early return causes issues when a page with the polyfill
+    // is loaded from the BFCache. Ideally, this code gets fixed instead of
+    // the workaround which clears the proxyAnimations cache on pagehide.
+    // See https://github.com/flackr/scroll-timeline/issues/146#issuecomment-1698159183
+    // for details.
     if (animations[i].animation == animation)
       return;
   }

--- a/src/scroll-timeline-css.js
+++ b/src/scroll-timeline-css.js
@@ -171,4 +171,12 @@ export function initCSSPolyfill() {
       }
     });
   });
+
+  // Clear cache containing the ProxyAnimation instances when leaving the page.
+  // See https://github.com/flackr/scroll-timeline/issues/146#issuecomment-1698159183
+  // for details.
+  window.addEventListener('pagehide', (e) => {
+    console.log('pagehide');
+    proxyAnimations = new WeakMap();
+  }, false);
 }

--- a/src/scroll-timeline-css.js
+++ b/src/scroll-timeline-css.js
@@ -176,7 +176,6 @@ export function initCSSPolyfill() {
   // See https://github.com/flackr/scroll-timeline/issues/146#issuecomment-1698159183
   // for details.
   window.addEventListener('pagehide', (e) => {
-    console.log('pagehide');
     proxyAnimations = new WeakMap();
   }, false);
 }


### PR DESCRIPTION
This PR clear the `proxyAnimations` cache when the page gets unloaded [using the unload event](https://webkit.org/blog/516/webkit-page-cache-ii-the-unload-event/). By clearing that cache new `ProxyAnimation` instances get created when going back using the browsers’s history.

This is needed for Safari, whose BFCache doesn’t play nice with this polyfill. See https://github.com/flackr/scroll-timeline/issues/146#issuecomment-1698159183 for more details.

Fixes #146.