### PR TITLE
Fix setting the effect

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -849,7 +849,8 @@ export class ProxyAnimation {
     return details.effect;
   }
   set effect(newEffect) {
-    proxyAnimations.get(this).animation.effect = newEffect;
+    const details = proxyAnimations.get(this);
+    details.animation.effect = newEffect;
     // Reset proxy to force re-initialization the next time it is accessed.
     details.effect = null;
   }


### PR DESCRIPTION
Demo: https://codepen.io/bramus/pen/oNJxoOX/a1a2b578349faf9299bb18c778fe4cf3

In this demo, the `effect` – which uses a `ScrollTimeline` as its `timeline` – on an animation is being set.

When doing so, this error gets thrown:

```
ReferenceError: Can't find variable: details
```

This because that variable is not declared within that function:

https://github.com/flackr/scroll-timeline/blob/5fab1816ad4f13e2cef3cd27ce6b243027a4970f/src/proxy-animation.js#L851-L855

This PR fixes that.

