### PR TITLE
Update CSS example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Also works with CSS Animations that use a `view-timeline` or `scroll-timeline`
 
 ```css
 @keyframes parallax-effect {
-  to { transform: 'translateY(100px)' }
+  to { transform: translateY(100px) }
 }
 #parallax {
   animation: parallax-effect linear both;


### PR DESCRIPTION
If you copy the CSS example in the readme, the `translateY` contains 2 quotes. Therefore, this isn't valid CSS and the example doesn't work out of the box. Removing the quotes resolves to a valid example.