### PR TITLE
Validate `axis` in constructor + fix axis update regression

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { isValidAxis } from "./utils.js";
 import { installCSSOM } from "./proxy-cssom.js";
 installCSSOM();
 
@@ -241,7 +242,11 @@ export class ScrollTimeline {
 
     if ((options && options.axis !== undefined) && 
         (options.axis != DEFAULT_TIMELINE_AXIS)) {
-      this.axis = options.axis;
+      if (!isValidAxis(options.axis)) {
+        throw TypeError("Invalid axis");
+      }
+
+      scrollTimelineOptions.get(this).axis = options.axis;
     }
 
     updateInternal(this);
@@ -257,11 +262,10 @@ export class ScrollTimeline {
   }
 
   set axis(axis) {
-    if (
-      ["block", "inline", "x", "y"].indexOf(axis) === -1
-    ) {
+    if (!isValidAxis(axis)) {
       throw TypeError("Invalid axis");
     }
+
     scrollTimelineOptions.get(this).axis = axis;
     updateInternal(this);
   }

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { isValidAxis } from "./utils.js";
 import { installCSSOM } from "./proxy-cssom.js";
 installCSSOM();
 
@@ -242,7 +241,7 @@ export class ScrollTimeline {
 
     if ((options && options.axis !== undefined) && 
         (options.axis != DEFAULT_TIMELINE_AXIS)) {
-      if (!isValidAxis(options.axis)) {
+      if (!ScrollTimeline.isValidAxis(options.axis)) {
         throw TypeError("Invalid axis");
       }
 
@@ -262,7 +261,7 @@ export class ScrollTimeline {
   }
 
   set axis(axis) {
-    if (!isValidAxis(axis)) {
+    if (!ScrollTimeline.isValidAxis(axis)) {
       throw TypeError("Invalid axis");
     }
 
@@ -325,6 +324,10 @@ export class ScrollTimeline {
 
   get __polyfill() {
     return true;
+  }
+
+  static isValidAxis(axis) {
+    return ["block", "inline", "x", "y"].includes(axis);
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,3 +12,7 @@ export function parseLength(obj, acceptStr) {
   }
   return null;
 }
+
+export function isValidAxis(axis) {
+  return ["block", "inline", "x", "y"].includes(axis);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,3 @@ export function parseLength(obj, acceptStr) {
   }
   return null;
 }
-
-export function isValidAxis(axis) {
-  return ["block", "inline", "x", "y"].includes(axis);
-}


### PR DESCRIPTION
Merging #140 introduced a regression making https://flackr.github.io/scroll-timeline/demo/view-timeline/ no longer work. Upon updating the axis, it always remained `block` (the default value). This is because the `this.axis` was directly manipulated, instead of storing it in the options.

Furthermore, the setter – which validates the axis – didn’t get called in the constructor, so we need to explicitly validate the axis in the constructor as well.

This PR fixes all that.