### PR TITLE
Stop processing ScrollTimeline props if no animation-related properties have been declared

### DIFF
--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -212,7 +212,9 @@ export class StyleParser {
     this.saveSourceSelectorToScrollTimeline(rule);
     this.saveSubjectSelectorToViewTimeline(rule);
 
-    if(!hasAnimationTimeline && !hasAnimationName && !hasAnimation) return;
+    if (!hasAnimationTimeline && !hasAnimationName && !hasAnimation) {
+      return;
+    }
 
     let timelineNames = [];
     let animationNames = [];

--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -212,6 +212,8 @@ export class StyleParser {
     this.saveSourceSelectorToScrollTimeline(rule);
     this.saveSubjectSelectorToViewTimeline(rule);
 
+    if(!hasAnimationTimeline && !hasAnimationName && !hasAnimation) return;
+
     let timelineNames = [];
     let animationNames = [];
     let shouldReplacePart = false;


### PR DESCRIPTION
While debugging something for #153, I noticed that `saveInRelationList` was being called once per ruleset – even though only 1 of the processed ruleset in my test had animation-related properties declared.

This PR adds a quick perf win by bailing out early from the `handleScrollTimelineProps` method in case no animation-related properties have been extracted.