### PR TITLE
Account for subject borders

### DIFF
--- a/demo/view-timeline/index.html
+++ b/demo/view-timeline/index.html
@@ -52,6 +52,7 @@
   }
 
   #target {
+    box-sizing: border-box;
     background-color:  rgba(0, 0, 255, 0.5);
     display:  inline-block;
     flex:  none;
@@ -61,6 +62,10 @@
 
   #target.taller {
     height: 650px;
+  }
+
+  #target.borders {
+    border: 25px solid #e0c58b;
   }
 
   #container.rtl > #target,
@@ -133,6 +138,8 @@
   <br>
   <input type="checkbox" name="subject-size" id="taller-than-scrollport-subject">
   <label for="taller-than-scrollport-subject">Taller than scrollport subject</label>
+  <input type="checkbox" name="subject-borders" id="subject-has-borders">
+  <label for="subject-has-borders">Subject has borders</label>
 </body>
 <script src="../../dist/scroll-timeline.js"></script>
 <script type="text/javascript">
@@ -204,6 +211,13 @@
             target.classList.add('taller');
           } else {
             target.classList.remove('taller');
+          }
+          break;
+        case 'subject-borders':
+          if(event.target.checked) {
+            target.classList.add('borders');
+          } else {
+            target.classList.remove('borders');
           }
           break;
       }

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -481,14 +481,14 @@ export function calculateRange(phase, container, target, axis, optionsInset) {
   if (axis == 'x' ||
       (axis == 'inline' && horizontalWritingMode) ||
       (axis == 'block' && !horizontalWritingMode)) {
-    viewSize = target.clientWidth;
+    viewSize = target.offsetWidth;
     viewPos = left;
     if (rtl)
       viewPos += container.scrollWidth - container.clientWidth;
     containerSize = container.clientWidth;
   } else {
     // TODO: support sideways-lr
-    viewSize = target.clientHeight;
+    viewSize = target.offsetHeight;
     viewPos = top;
     containerSize = container.clientHeight;
   }


### PR DESCRIPTION
This PR fixes https://github.com/flackr/scroll-timeline/issues/165

The polyfill used clientWidth/Height to calculate the size of the principal box of the subject, but clientWidth/Height does not include borders. This caused errors when calculating ranges. 