### PR TITLE
Add value getter to CSSMathInvert and CSSMathNegate

### DIFF
--- a/src/proxy-cssom.js
+++ b/src/proxy-cssom.js
@@ -120,11 +120,19 @@ export function installCSSOM() {
       constructor(values) {
         super([arguments[0]], 'negate', '-');
       }
+
+      get value() {
+        return  privateDetails.get(this).values[0];
+      }
     },
 
     'CSSMathInvert': class extends MathOperation {
       constructor(values) {
         super([1, arguments[0]], 'invert', 'calc', ' / ');
+      }
+
+      get value() {
+        return  privateDetails.get(this).values[1];
       }
     },
 


### PR DESCRIPTION
Solves #169

This PR adds a getter for `value` to the CSSMathInvert and CSSMathNegate classes. 

While this does not remove the `values` getter on the MathOperation superclass, it makes sure that code calling .value on instances of these classes won't fail.  