### PR TITLE
Defer tickAnimation to requestAnimationFrame to prevent relayout and ResizeObserver errors

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -34,9 +34,11 @@ function updateInternal(scrollTimelineInstance) {
   let animations = details.animations;
   if (animations.length === 0) return;
   let timelineTime = scrollTimelineInstance.currentTime;
-  for (let i = 0; i < animations.length; i++) {
-    animations[i].tickAnimation(timelineTime);
-  }
+  requestAnimationFrame(() => {
+    for (let i = 0; i < animations.length; i++) {
+      animations[i].tickAnimation(timelineTime);
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
In updateInternal we call .currentTime before updating animations. 

When there's multiple ViewTimelines, updateInternal will be called individually for each timeline on the scroll event, causing unnecessary reflow. It also causes ResizeObserver to throw a "ResizeObserver loop completed with undelivered notifications." error.

Deferring tickAnimation to requestAnimationFrame to complete all calls to currentTime before ticking animations.


Example of unexpected errors in /scroll-timelines/finish-animation.html:

**Before**
<img width="942" alt="image" src="https://github.com/flackr/scroll-timeline/assets/175195/bfad9252-2946-4677-b9c9-73db1364e0b2">

**After**
<img width="944" alt="image" src="https://github.com/flackr/scroll-timeline/assets/175195/06f58375-a21f-42cb-8697-40a8d48ee419">
