### PR TITLE
Handle scroll and resize events only once for each scroll source

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -603,8 +603,10 @@ function tickAnimation(timelineTime) {
 
 function renormalizeTiming() {
   const details = proxyAnimations.get(this);
-  // Force renormalization.
-  details.specifiedTiming = null;
+  if (details) {
+    // Force renormalization.
+    details.specifiedTiming = null;
+  }
 }
 
 function notifyReady(details) {


### PR DESCRIPTION
Currently each timeline sets up its own scroll listener and resize observer on the source element. As a result we sample scroll position and update animations for each timeline, potentially causing relayouts. (As reported in #46).

This PR registers switches to using only one scroll listener and resize observer per source element, and to sample scroll position only once before updating the timelines and their connected animations.