### PR TITLE
Disable effect without cancelling animation

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -574,10 +574,16 @@ function tickAnimation(timelineTime) {
   const details = proxyAnimations.get(this);
   if (timelineTime == null) {
     // While the timeline is inactive, it's effect should not be applied.
-    // To polyfill this behavior, we cancel the underlying animation.
-    if (details.animation.playState != 'idle')
-      details.animation.cancel();
+    // To polyfill this behavior, we remove the underlying effect from animation and store it
+    if (details.animation.effect) {
+      details.tempEffect = details.animation.effect
+      details.animation.effect = null
+    }
     return;
+  } else if (details.animation.effect === null && details.tempEffect) {
+    // Restore effect if it previously was removed due to an inactive timeline
+    details.animation.effect = details.tempEffect
+    details.tempEffect = null
   }
 
   if (details.pendingTask) {

--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -576,14 +576,14 @@ function tickAnimation(timelineTime) {
     // While the timeline is inactive, it's effect should not be applied.
     // To polyfill this behavior, we remove the underlying effect from animation and store it
     if (details.animation.effect) {
-      details.tempEffect = details.animation.effect
-      details.animation.effect = null
+      details.tempEffect = details.animation.effect;
+      details.animation.effect = null;
     }
     return;
   } else if (details.animation.effect === null && details.tempEffect) {
     // Restore effect if it previously was removed due to an inactive timeline
-    details.animation.effect = details.tempEffect
-    details.tempEffect = null
+    details.animation.effect = details.tempEffect;
+    details.tempEffect = null;
   }
 
   if (details.pendingTask) {


### PR DESCRIPTION
If the timeline is inactive, the current implementation disables the effect by cancelling the underlying animation. 
This can cause issues. If the animation is later cancelled "for real" the animation is already idle and no `cancel` event will be emitted.

One example of code that is affected is the WPT subtest 'oncancel event is fired when the timeline is inactive.' in cancel-animation.html.

```js
  await waitForNextFrame();
  animation.play();
  await animation.ready;

  // Make the scroll timeline inactive.
  scroller.style.overflow = 'visible';
  scroller.scrollTop;
  await waitForNextFrame();
  // If the polyfill listens for style changes, the timeline should be inactive by this point.
  assert_equals(animation.timeline.currentTime, null,
                'Sanity check the timeline is inactive.');

  const eventWatcher = new EventWatcher(t, animation, 'cancel');
  animation.cancel();
  const cancelEvent = await eventWatcher.wait_for('cancel');
  // Cancel event will not be emitted, and we will never reach code below this point.
```

This test will time out if the timeline is updated when the source style is changed.
The polyfill currently don't detect style changes, and fails at the sanity check, 
but in the future (PR https://github.com/flackr/scroll-timeline/pull/177) I expect that we will react to style changes.

This PR tries to work around the issue by temporary removing the effect, instead of cancelling the animation, when the timeline is inactive.