### PR TITLE
Proxied Animations Cleanup fixup

### DIFF
--- a/src/scroll-timeline-css.js
+++ b/src/scroll-timeline-css.js
@@ -159,11 +159,4 @@ export function initCSSPolyfill() {
       }
     });
   });
-
-  // Clear cache containing the ProxyAnimation instances when leaving the page.
-  // See https://github.com/flackr/scroll-timeline/issues/146#issuecomment-1698159183
-  // for details.
-  window.addEventListener('pagehide', (e) => {
-    proxyAnimations = new WeakMap();
-  }, false);
 }


### PR DESCRIPTION
In #89 the proxied animations handling got moved around a bit. In #147 (which was merged earlier) a cleanup mechanism for the old `proxyAnimations` was introduced, but this mechanism was not removed in #89. This went unnoticed as it only triggers an error when running in strict mode, as reported in #183.

This PR fixes that.