### PR TITLE
Only return 'normal' as the range when no value is given.

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -1799,13 +1799,16 @@ function parseTimelineRangeOffset(value, position) {
 
 // Parses a given animation-range value (string)
 function parseAnimationRange(value) {
-  const animationRange = {
-    start: 'normal',
-    end: 'normal'
-  };
-
   if (!value)
-    return animationRange;
+    return {
+      start: 'normal',
+      end: 'normal'
+    };
+  
+  const animationRange = {
+    start: { rangeName: 'cover', offset: CSS.percent(0) },
+    end: { rangeName: 'cover', offset: CSS.percent(100) },
+  };
 
   // Format:
   // <start-name> <start-offset> <end-name> <end-offset>


### PR DESCRIPTION
In #178 `parseAnimationRange` was changed to use string values of `"normal"` instead of objects representing the normal range. This essentially broke the parsing of `animation-range`, as later on that function tries to update values in that (now inexistent) object.

On the console, these errors could be seen, as reported in #183:

```
Can’t assign to property "rangeName": not an object
```

This PR fixes this: return the default `"normal"` when no value is given, but continue with the objects when there is a value to parse.

Note that this is only for parsing ranges of `ViewTimelime` instances. For `ScrollTimeline`, more work needs to be done in #153.

_PS: I didn’t get to updating the test results as I’ve got issues launching them with firefox for some reason. Safari works fine, but gives totally different base results._