### PR TITLE
Don’t try ticking the animation if there are no details

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -633,6 +633,8 @@ function playInternal(details, autoRewind) {
 
 function tickAnimation(timelineTime) {
   const details = proxyAnimations.get(this);
+  if (!details) return;
+
   if (timelineTime == null) {
     // While the timeline is inactive, it's effect should not be applied.
     // To polyfill this behavior, we cancel the underlying animation.


### PR DESCRIPTION
I believe this is a regression introduce by #89. When using the polyfill in Safari (which hash a BFCache), one would get errors about trying to read `autoAlignStartTime` from the `details`.

Narrowing things down and working my way up the call tree, the root cause is in `tickAnimation` which tries to get the `details` from the `proxyAnimations`. Since `proxyAnimations` gets cleared on `pagehide`, `details` _can_ be empty, so the whole ticking stop stop if no details are present.

This PR fixes that.