### PR TITLE
Auto align start time before checking if animation is ready

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -42,7 +42,8 @@ function createReadyPromise(details) {
     if (timelineTime === null) {
       return
     }
-
+    // Run auto align start time procedure, in case measurements are ready
+    autoAlignStartTime(details);
     if (details.pendingTask === 'play' && (details.startTime !== null || details.holdTime !== null)) {
       commitPendingPlay(details);
     } else if (details.pendingTask === 'pause') {


### PR DESCRIPTION
Run the auto align start time procedure before checking if animation is ready. 

Currently we run the procedure when ticking animations after adding animations to a timeline or after a scroll or resize event. 
However, this does not update the start time when playing or pausing an existing animation. 

If we don't run the procedure here, tests _can_ time out under some conditions, as the animation will never be ready. This can happen in the [play-animation test](https://github.com/web-platform-tests/wpt/blob/a95a859194890421952a3105e9b69789dbb4c58b/scroll-animations/scroll-timelines/play-animation.html#L130).

No tests should be affected by this PR, but fixing this is a precondition for fixing other issues.