### PR TITLE
Handle undefined options in updateTimingHandler

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -779,6 +779,9 @@ function createProxyEffect(details) {
   };
   const updateTimingHandler = {
     apply: function(target, thisArg, argumentsList) {
+      if (!argumentsList || !argumentsList.length)
+        return;
+
       // Additional validation that is specific to scroll timelines.
       if (details.timeline) {
         const options = argumentsList[0];


### PR DESCRIPTION
Handle case where `effect.updateTiming()` is called with an undefined input.

This happens in the [view-timeline-subject-size-changes test](https://github.com/web-platform-tests/wpt/blob/a95a859194890421952a3105e9b69789dbb4c58b/scroll-animations/view-timelines/view-timeline-subject-size-changes.html#L53).

The PR does not fix the entire test, but it fixes the following error: 
```
promise_test: Unhandled rejection with value: object "TypeError: options is undefined"
```

I will create a separate PR for fixing the test later on.