### PR TITLE
Prevent redundant updates to timelines and animations

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -230,6 +230,9 @@ function updateMeasurements(source) {
     }
   }
 
+  if (details.updateScheduled)
+    return;
+
   requestAnimationFrame(() => {
     // Defer ticking timeline to animation frame to prevent
     // "ResizeObserver loop completed with undelivered notifications"
@@ -239,7 +242,10 @@ function updateMeasurements(source) {
         updateInternal(timeline);
       }
     }
+
+    details.updateScheduled = false;
   });
+  details.updateScheduled = true;
 }
 
 function updateSource(timeline, source) {


### PR DESCRIPTION
Calls to `updateMeasurements()` schedules a task to update timelines and animations.

`updateMeasurements()` can potentially be called multiple times before the scheduled task is executed. If a task is already scheduled, scheduling new tasks would be redundant.