### PR TITLE
Handle explicitly undefined options argument in updateTimingHandler

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -784,7 +784,7 @@ function createProxyEffect(details) {
         return;
 
       // Additional validation that is specific to scroll timelines.
-      if (details.timeline) {
+      if (details.timeline && argumentsList[0]) {
         const options = argumentsList[0];
         const duration = options.duration;
         if (duration === Infinity) {


### PR DESCRIPTION
This is a follow up on #191.

Handle case where effect.updateTiming() is called with an explicit undefined options argument.

This happens in the [view-timeline-subject-size-changes test](https://github.com/web-platform-tests/wpt/blob/a95a859194890421952a3105e9b69789dbb4c58b/scroll-animations/view-timelines/view-timeline-subject-size-changes.html#L53).

After a discussion in #191 we skipped checking for an explicitly undefined options argument, and instead returned if the argumentList was undefined or empty. That does not cover the case where the method is called explicitly with undefined as an argument as below. 

```js
effect.updateTiming(undefined)
// argumentList == [undefined]
// arguementList.length == 1
```