### PR TITLE
Avoid compressing constructor names when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "microbundle -f iife",
     "dev": "run-all \"serve\" \" microbundle watch -f iife \"",
     "deploy": "npm run build",
-    "test-setup": "node test/setup/checkout-wpt.mjs",
+    "test-setup": "node test/setup/checkout-wpt.mjs && npm run build -- --no-compress",
     "test:wpt": "npm run test-setup && cd test && cd wpt && (python wpt run --headless -y --log-wptreport ../report/data.json --log-wptscreenshot=../report/screenshots.txt --log-html=../report/index.html --inject-script ../../dist/scroll-timeline.js firefox scroll-animations || true)",
     "test:simple": "npm run test-setup && cd test && cd wpt && python wpt serve --inject-script ../../dist/scroll-timeline.js",
     "test:compare": "node test/summarize-json.mjs test/report/data.json > test/report/summary.txt && echo 'Comparing test results. If different and expected, patch the following diff to test/expected.txt:' && diff test/expected.txt test/report/summary.txt"

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -672,7 +672,7 @@ PASS	/scroll-animations/scroll-timelines/idlharness.window.html	Element includes
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	Element includes Slottable: member names are unique
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface object
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface object length
-FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface object name
+PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface object name
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface prototype object
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface prototype object's "constructor" property
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface prototype object's @@unscopables property
@@ -684,7 +684,7 @@ PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline i
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: new ScrollTimeline() must inherit property "axis" with the proper type
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface object
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface object length
-FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface object name
+PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface object name
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface prototype object
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface prototype object's "constructor" property
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface prototype object's @@unscopables property
@@ -957,4 +957,4 @@ FAIL	/scroll-animations/view-timelines/view-timeline-sticky-block.html	View time
 FAIL	/scroll-animations/view-timelines/view-timeline-sticky-inline.html	View timeline with sticky target, block axis.
 FAIL	/scroll-animations/view-timelines/view-timeline-subject-size-changes.html	View timeline with subject size change after the creation of the animation
 FAIL	/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html	Intrinsic iteration duration is non-negative
-Passed 432 of 959 tests.
+Passed 434 of 959 tests.


### PR DESCRIPTION
Adding this PR for discussion. 

Microbundle compresses the build with terser by default. This results in CSSOM constructor names being replaced with `t` or similarly compressed names, which causes some subtests to fail. 

Subtests using the [css-typed-om test-helper.js](https://github.com/web-platform-tests/wpt/blob/master/css/css-typed-om/resources/testhelper.js#L52) fail, as the test-helper uses the constructor name to determine how to compare arguments.

I don't think microbundle allows for configuring terser directly. Configuration seems to be limited to enabling or disabling compression. The only available option I can see is building an uncompressed bundle for testing. Otherwise we would need to configure rollup, babel and terser ourself to ensure terser doesn't compress constructor names.