### PR TITLE
Handle case in simplify calculation where the root is a CSSMathProduct with one child

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "microbundle -f iife",
     "dev": "run-all \"serve\" \" microbundle watch -f iife \"",
     "deploy": "npm run build",
-    "test-setup": "node test/setup/checkout-wpt.mjs",
+    "test-setup": "node test/setup/checkout-wpt.mjs && npm run build -- --no-compress",
     "test:wpt": "npm run test-setup && cd test && cd wpt && (python wpt run --headless -y --log-wptreport ../report/data.json --log-wptscreenshot=../report/screenshots.txt --log-html=../report/index.html --inject-script ../../dist/scroll-timeline.js firefox scroll-animations || true)",
     "test:simple": "npm run test-setup && cd test && cd wpt && python wpt serve --inject-script ../../dist/scroll-timeline.js",
     "test:compare": "node test/summarize-json.mjs test/report/data.json > test/report/summary.txt && echo 'Comparing test results. If different and expected, patch the following diff to test/expected.txt:' && diff test/expected.txt test/report/summary.txt"

--- a/src/simplify-calculation.js
+++ b/src/simplify-calculation.js
@@ -295,8 +295,14 @@ export function simplifyCalculation(root, info) {
       }
     }
 
-    // Return root.
-    return new CSSMathProduct(...children);
+    if (children.length === 1) {
+      // Handle case where root is a product node with only one child,
+      // and that child can not be expressed in the canonical unit.
+      return children[0];
+    } else {
+      // Return root.
+      return new CSSMathProduct(...children);
+    }
   }
   // Return root.
   return root;

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -932,7 +932,7 @@ FAIL	/scroll-animations/view-timelines/timeline-offset-in-keyframe.html	Timeline
 FAIL	/scroll-animations/view-timelines/timeline-offset-in-keyframe.html	Timeline offsets in programmatic keyframes resolved when updating the animation effect
 FAIL	/scroll-animations/view-timelines/unattached-subject-inset.html	Creating a view timeline with a subject that is not attached to the document works as expected
 FAIL	/scroll-animations/view-timelines/view-timeline-get-current-time-range-name.html	View timeline current time for named range
-FAIL	/scroll-animations/view-timelines/view-timeline-get-set-range.html	Getting and setting the animation range
+PASS	/scroll-animations/view-timelines/view-timeline-get-set-range.html	Getting and setting the animation range
 PASS	/scroll-animations/view-timelines/view-timeline-inset.html	View timeline with px based inset.
 PASS	/scroll-animations/view-timelines/view-timeline-inset.html	View timeline with percent based inset.
 PASS	/scroll-animations/view-timelines/view-timeline-inset.html	view timeline with inset auto.
@@ -957,4 +957,4 @@ FAIL	/scroll-animations/view-timelines/view-timeline-sticky-block.html	View time
 FAIL	/scroll-animations/view-timelines/view-timeline-sticky-inline.html	View timeline with sticky target, block axis.
 FAIL	/scroll-animations/view-timelines/view-timeline-subject-size-changes.html	View timeline with subject size change after the creation of the animation
 FAIL	/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html	Intrinsic iteration duration is non-negative
-Passed 434 of 959 tests.
+Passed 435 of 959 tests.

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -672,7 +672,7 @@ PASS	/scroll-animations/scroll-timelines/idlharness.window.html	Element includes
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	Element includes Slottable: member names are unique
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface object
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface object length
-FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface object name
+PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface object name
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface prototype object
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface prototype object's "constructor" property
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: existence and properties of interface prototype object's @@unscopables property
@@ -684,7 +684,7 @@ PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline i
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ScrollTimeline interface: new ScrollTimeline() must inherit property "axis" with the proper type
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface object
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface object length
-FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface object name
+PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface object name
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface prototype object
 FAIL	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface prototype object's "constructor" property
 PASS	/scroll-animations/scroll-timelines/idlharness.window.html	ViewTimeline interface: existence and properties of interface prototype object's @@unscopables property
@@ -957,4 +957,4 @@ FAIL	/scroll-animations/view-timelines/view-timeline-sticky-block.html	View time
 FAIL	/scroll-animations/view-timelines/view-timeline-sticky-inline.html	View timeline with sticky target, block axis.
 FAIL	/scroll-animations/view-timelines/view-timeline-subject-size-changes.html	View timeline with subject size change after the creation of the animation
 FAIL	/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html	Intrinsic iteration duration is non-negative
-Passed 432 of 959 tests.
+Passed 434 of 959 tests.


### PR DESCRIPTION
Depends on #200 

Handle case in simplify calculation where the root has been simplified to a CSSMathProduct with one child.

If that child could be expressed in the canonical unit, it would have been simplified further, however if the child has a unit  such as percent that can't be resolved further, it will not be simplified.
