### PR TITLE
Prevent invalid-regular expression syntax error in Safari < 16.4

### DIFF
--- a/src/proxy-cssom.js
+++ b/src/proxy-cssom.js
@@ -97,7 +97,7 @@ export function installCSSOM() {
    */
   function parseCSSMultiplication(str) {
     let values = [];
-    const tokens = str.split(/(?<!\([^\)]*)([*])(?![^\(]*\))/);
+    const tokens = str.split(new RegExp('(?<!\\([^\\)]*)([*])(?![^\\(]*\\))'));
     values.push(parseCSSDivision(tokens.shift()));
     while (tokens.length) {
       tokens.shift(); // Consume operator '*'
@@ -113,7 +113,7 @@ export function installCSSOM() {
    */
   function parseCSSDivision(str) {
     let values = [];
-    const tokens = str.split(/(?<!\([^\)]*)([/])(?![^\(]*\))/);
+    const tokens = str.split(new RegExp('(?<!\\([^\\)]*)([/])(?![^\\(]*\\))'));
     values.push(parseCSSNumericValue(tokens.shift()));
     while (tokens.length) {
       tokens.shift(); // Consume operator '/'
@@ -129,7 +129,7 @@ export function installCSSOM() {
    */
   function parseCSSMathSum(str) {
     let values = [];
-    const tokens = str.split(/(?<!\([^\)]*)(\s[+-]\s)(?![^\(]*\))/);
+    const tokens = str.split(new RegExp('(?<!\\([^\\)]*)(\\s[+-]\\s)(?![^\\(]*\\))'));
     values.push(parseCSSMultiplication(tokens.shift()));
     while (tokens.length) {
       let op = tokens.shift();

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -705,7 +705,7 @@ function parseInset(value) {
   // Parse string parts to
   if (typeof value === 'string') {
     // Split value into separate parts
-    const stringParts = value.split(/(?<!\([^\)]*)\s(?![^\(]*\))/);
+    const stringParts = value.split(new RegExp('(?<!\\([^\\)]*)\\s(?![^\\(]*\\))'));
     parts = stringParts.map(str => {
       if (str.trim() === 'auto') {
         return 'auto';


### PR DESCRIPTION
PR #177 added regular expressions to parse CSSNumericValue objects using lookbehind. Safari only supports lookbehind starting from version 16.4 [1]. In earlier versions loading the polyfill causes an error of the form:

```
SyntaxError: Invalid regular expression: invalid group specifier name
```

Compile RegExp on demand to ensure the polyfill can be loaded without errors. Since the relevant functions are only called initially when parsing options, the performance overhead appears limited.

[1] https://caniuse.com/js-regexp-lookbehind