### PR TITLE
Set default anonymous source to nearest

### DIFF
--- a/src/scroll-timeline-css-parser.js
+++ b/src/scroll-timeline-css-parser.js
@@ -120,7 +120,7 @@ export class StyleParser {
       return {
         anonymousSource: options.source,
         anonymousTarget: target,
-        source: getAnonymousSourceElement(options.source, target),
+        source: getAnonymousSourceElement(options.source ?? 'nearest', target),
         axis: (options.axis ? options.axis : 'block'),
       };
     }

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -905,6 +905,7 @@ PASS	/scroll-animations/view-timelines/block-view-timeline-current-time.tentativ
 FAIL	/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html	View timeline with subject that is not a direct descendant of the scroll container
 FAIL	/scroll-animations/view-timelines/change-animation-range-updates-play-state.html	Changing the animation range updates the play state
 FAIL	/scroll-animations/view-timelines/contain-alignment.html	Stability of animated elements aligned to the bounds of a contain region
+PASS	/scroll-animations/view-timelines/fieldset-source.html	Fieldset is a valid source for a view timeline
 FAIL	/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html	Report specified timeline offsets
 FAIL	/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html	Computed offsets can be outside [0,1] for keyframes with timeline offsets
 FAIL	/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html	Retain specified ordering of keyframes with timeline offsets
@@ -957,4 +958,4 @@ FAIL	/scroll-animations/view-timelines/view-timeline-sticky-block.html	View time
 FAIL	/scroll-animations/view-timelines/view-timeline-sticky-inline.html	View timeline with sticky target, block axis.
 FAIL	/scroll-animations/view-timelines/view-timeline-subject-size-changes.html	View timeline with subject size change after the creation of the animation
 FAIL	/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html	Intrinsic iteration duration is non-negative
-Passed 432 of 959 tests.
+Passed 433 of 960 tests.


### PR DESCRIPTION
The [progress demo](https://flackr.github.io/scroll-timeline/demo/basic/progress) is currently throwing a "TypeError: Invalid ScrollTimeline Source Type". 

This happens because
1. `parseAnonymousScrollTimeline()` does not set a default source
2. `getAnonymousSourceElement()` requires a source, and will throw an error if one is not set.

Adding 'nearest' as a default anonymous source in `getAnonymousScrollTimelineOptions()`, the same place a default value for `axis` is set. 


https://github.com/flackr/scroll-timeline/blob/db93642a02f0271c2a96a1f15861d04813b67b10/src/scroll-timeline-css-parser.js#L465-L481

https://github.com/flackr/scroll-timeline/blob/db93642a02f0271c2a96a1f15861d04813b67b10/src/scroll-timeline-css-parser.js#L117-L129

https://github.com/flackr/scroll-timeline/blob/db93642a02f0271c2a96a1f15861d04813b67b10/src/scroll-timeline-base.js#L493-L504

