### PR TITLE
Add utility function to split string into component values

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -14,7 +14,7 @@
 
 import {installCSSOM} from "./proxy-cssom.js";
 import {simplifyCalculation} from "./simplify-calculation";
-import {normalizeAxis} from './utils.js';
+import {normalizeAxis, splitIntoComponentValues} from './utils.js';
 
 installCSSOM();
 
@@ -721,17 +721,14 @@ function parseInset(value) {
   let parts = value;
   // Parse string parts to
   if (typeof value === 'string') {
-    // Split value into separate parts
-    const stringParts = value.split(/(?<!\([^\)]*)\s(?![^\(]*\))/);
-    parts = stringParts.map(str => {
-      if (str.trim() === 'auto') {
+    parts = splitIntoComponentValues(value).map(str => {
+      if (str === 'auto') {
         return 'auto';
-      } else {
-        try {
-          return CSSNumericValue.parse(str);
-        } catch (e) {
-          throw TypeError('Invalid inset');
-        }
+      }
+      try {
+        return CSSNumericValue.parse(str);
+      } catch (e) {
+        throw TypeError(`Could not parse inset "${value}"`);
       }
     });
   }
@@ -784,7 +781,7 @@ function calculateInset(value, sizes) {
 export function fractionalOffset(timeline, value) {
   if (timeline instanceof ViewTimeline) {
     const { rangeName, offset } = value;
-  
+
     const phaseRange = range(timeline, rangeName);
     const coverRange = range(timeline, 'cover');
 
@@ -794,17 +791,17 @@ export function fractionalOffset(timeline, value) {
   if (timeline instanceof ScrollTimeline) {
     const { axis, source } = timeline;
     const { sourceMeasurements } = sourceDetails.get(source);
-  
+
     let sourceScrollDistance = undefined;
     if (normalizeAxis(axis, sourceMeasurements) === 'x') {
       sourceScrollDistance = source.scrollWidth;
     } else {
       sourceScrollDistance = source.scrollHeight;
     }
-  
+
     const position = resolvePx(value, sourceScrollDistance);
     const fractionalOffset = position / sourceScrollDistance;
-  
+
     return fractionalOffset;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,3 +22,59 @@ export function normalizeAxis(axis, computedStyle) {
 
   return axis;
 }
+
+/**
+ * Split an input string into a list of individual component value strings,
+ * so that each can be handled as a keyword or parsed with `CSSNumericValue.parse()`;
+ *
+ * Examples:
+ * splitIntoComponentValues('cover'); // ['cover']
+ * splitIntoComponentValues('auto 0%'); // ['auto', '100%']
+ * splitIntoComponentValues('calc(0% + 50px) calc(100% - 50px)'); // ['calc(0% + 50px)', 'calc(100% - 50px)']
+ * splitIntoComponentValues('1px 2px').map(val => CSSNumericValue.parse(val)) // [new CSSUnitValue(1, 'px'), new CSSUnitValue(2, 'px')]
+ *
+ * @param {string} input
+ * @return {string[]}
+ */
+export function splitIntoComponentValues(input) {
+  const res = [];
+  let i = 0;
+
+  function consumeComponentValue() {
+    let level = 0;
+    const startIndex = i;
+    while (i < input.length) {
+      const nextChar = input.slice(i, i + 1);
+      if (/\s/.test(nextChar) && level === 0) {
+        break;
+      } else if (nextChar === '(') {
+        level += 1;
+      } else if (nextChar === ')') {
+        level -= 1;
+        if (level === 0) {
+          // Consume the next character and break
+          i++;
+          break;
+        }
+      }
+      i++;
+    }
+    return input.slice(startIndex, i);
+  }
+
+  function consumeWhitespace() {
+    while (/\s/.test(input.slice(i, i + 1))) {
+      i++;
+    }
+  }
+
+  while(i < input.length) {
+    const nextChar = input.slice(i, i + 1);
+    if (/\s/.test(nextChar)) {
+      consumeWhitespace();
+    } else {
+      res.push(consumeComponentValue());
+    }
+  }
+  return res;
+}


### PR DESCRIPTION
When parsing component values passed as a string to `rangeStart`, `rangeEnd` and `inset` we have previously used str.split(), either with a single whitespace or with a regex with various issues:

- `'calc(2 * 10px) auto'.split(' ')` returns `['calc(2', '*', '10px)', 'auto']`, breaking apart functions
- `'calc(2 * 10px) auto'.split(/(?<!\([^\)]*)\s(?![^\(]*\))/)` returns `['calc(2 * 10px)', 'auto']` as expected, but causes an error in browsers without support for lookahead

This PR adds a utility function `splitIntoComponentValues(input)` that splits a string with multiple component values into an array of individual component value strings. These can then be processed either as keywords or be further parsed using `CSSNumericValue.parse()`.

```js
splitIntoComponentValues('calc(2 * 10px) calc(2 * 5px)');
// [('calc(2 * 10px)', 'calc(2 * 5px)']

splitIntoComponentValues('10px 10px').map(val => CSSNumbericValue.parse(val));
// [new CSSUnitValue(10, 'px'), new CSSUnitValue(10, 'px')]
```