### PR TITLE
Account for insets when comparing size of subject to size of scrollport/view progress visibility range

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -669,6 +669,7 @@ export function calculateRange(phase, sourceMeasurements, subjectMeasurements, a
 
   let startOffset = undefined;
   let endOffset = undefined;
+  // Take inset into account when determining the scrollport size
   const adjustedScrollportSize = sizes.containerSize - inset.start - inset.end;
   const subjectIsLargerThanScrollport = viewSize > adjustedScrollportSize;
 

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -669,7 +669,8 @@ export function calculateRange(phase, sourceMeasurements, subjectMeasurements, a
 
   let startOffset = undefined;
   let endOffset = undefined;
-  const targetIsTallerThanContainer = viewSize > sizes.containerSize ? true : false;
+  const adjustedScrollportSize = sizes.containerSize - inset.start - inset.end;
+  const subjectIsLargerThanScrollport = viewSize > adjustedScrollportSize;
 
   switch(phase) {
     case 'cover':
@@ -694,11 +695,11 @@ export function calculateRange(phase, sourceMeasurements, subjectMeasurements, a
 
     case 'entry-crossing':
       startOffset = coverStartOffset;
-      endOffset = targetIsTallerThanContainer ? containEndOffset : containStartOffset;
+      endOffset = subjectIsLargerThanScrollport ? containEndOffset : containStartOffset;
       break;
 
     case 'exit-crossing':
-      startOffset = targetIsTallerThanContainer ? containStartOffset : containEndOffset;
+      startOffset = subjectIsLargerThanScrollport ? containStartOffset : containEndOffset;
       endOffset = coverEndOffset;
       break;
   }


### PR DESCRIPTION
We should account for insets when evaluating `targetIsTallerThanContainer`. 
Currently the range is slightly off when the subject is close in size to the inset adjusted scrollport.
