### PR TITLE
Remove test summary from test output.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,7 +54,7 @@ jobs:
         run: "npm run test:wpt"
       - name: Expected results
         run: "npm run test:compare"
-      - name: Adding summary
+      - name: Test results summary
         run: echo "Passed $(grep -c '^PASS' ./test/report/summary.txt) of $(grep -c '^'  ./test/report/summary.txt) tests" >> $GITHUB_STEP_SUMMARY
       - name: Clean build files
         run: "rm -rf node_modules test/wpt"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,6 +54,8 @@ jobs:
         run: "npm run test:wpt"
       - name: Expected results
         run: "npm run test:compare"
+      - name: Adding summary
+        run: echo "Passed $(grep -c '^PASS' ./test/report/summary.txt) of $(grep -c '^'  ./test/report/summary.txt) tests" >> $GITHUB_STEP_SUMMARY
       - name: Clean build files
         run: "rm -rf node_modules test/wpt"
       - name: Upload artifact

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -958,4 +958,3 @@ FAIL	/scroll-animations/view-timelines/view-timeline-sticky-block.html	View time
 FAIL	/scroll-animations/view-timelines/view-timeline-sticky-inline.html	View timeline with sticky target, block axis.
 FAIL	/scroll-animations/view-timelines/view-timeline-subject-size-changes.html	View timeline with subject size change after the creation of the animation
 FAIL	/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html	Intrinsic iteration duration is non-negative
-Passed 433 of 960 tests.

--- a/test/summarize-json.mjs
+++ b/test/summarize-json.mjs
@@ -17,4 +17,3 @@ for (let result of results) {
     }
   }
 }
-console.log(`Passed ${passes} of ${fails + passes} tests.`);


### PR DESCRIPTION
Having the summary line leads to every PR which alters test expectations conflicting with every other PR which alters them. The summary can be computed by grepping the PASS / FAIL lines anyways so this should reduce the number of merge conflicts to only cases where the same sets of test expectations changed.