### PR TITLE
Skip GitHub pages steps when using act to build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           submodules: recursive
       - name: Setup Pages
+        if: ${{ !env.ACT }}
         id: pages
         uses: actions/configure-pages@v3
       - name: Install Node.js dependencies
@@ -58,6 +59,7 @@ jobs:
         run: "rm -rf node_modules test/wpt"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
+        if: ${{ !env.ACT }}
         with:
           path: .
 


### PR DESCRIPTION
To run the GitHub actions locally, I use [`nektos/act`](https://github.com/nektos/act).

One of the things `act` can’t do are the GitHub Pages related actions. This PR alters the workflow to skips those steps when `act` is uses, as [per act instructions](https://github.com/nektos/act?tab=readme-ov-file#skipping-steps)