### PR TITLE
Speed up WPT checkout

### DIFF
--- a/test/setup/checkout-wpt.mjs
+++ b/test/setup/checkout-wpt.mjs
@@ -22,7 +22,7 @@ if (existsSync(checkoutDir)) {
   exit(0);
 }
 
-execSync(`git clone ${repoUrl}`, {...execEnv, cwd: path.resolve(`${__dirname}/..`)});
+execSync(`git clone --depth 1 --branch master --single-branch ${repoUrl}`, {...execEnv, cwd: path.resolve(`${__dirname}/..`)});
 console.warn('Ensure that you setup wpt for local test runs per published instructions: https://web-platform-tests.org/running-tests/from-local-system.html');
 console.log(`Checked out ${checkoutDir}`);
 


### PR DESCRIPTION
By shallow cloning and only cloning the master branch, the WPT setup can be sped up, thereby improving the overall speed of the build pipeline.

Without this change – and at the time of writing – 705377 files make up the entire WPT repo and its history. With it, only 89341 files need to be fetched.

See https://www.bram.us/2020/11/11/speed-up-build-times-with-this-little-git-trick/ for details about this trick.