### PR TITLE
Add todo to update code once auto-align issue is answered or closed

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -603,6 +603,7 @@ function playInternal(details, autoRewind) {
   // Additonal check for polyfill: Does not have the auto align start time flag set.
   // If we return when this flag is set, a play task will not be scheduled, leaving the animation in the
   // idle state. If the animation is in the idle state, the auto align procedure will bail.
+  // TODO: update with results of https://github.com/w3c/csswg-drafts/issues/9871
   if (details.holdTime === null && !details.autoAlignStartTime &&
       !abortedPause && details.pendingPlaybackRate === null)
     return;


### PR DESCRIPTION
It seems like animation.play() is returning early when running on a finite timeline with the auto-align start time procedure. 
We have implemented a way around the issue, but I finally managed to file a w3c issue: https://github.com/w3c/csswg-drafts/issues/9871.

Adding a todo comment to remind us to update the code once the issue is resolved.