### PR TITLE
Account for client width and height when calculating scroll distance

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -794,9 +794,9 @@ export function fractionalOffset(timeline, value) {
 
     let sourceScrollDistance = undefined;
     if (normalizeAxis(axis, sourceMeasurements) === 'x') {
-      sourceScrollDistance = source.scrollWidth;
+      sourceScrollDistance = sourceMeasurements.scrollWidth - sourceMeasurements.clientWidth;
     } else {
-      sourceScrollDistance = source.scrollHeight;
+      sourceScrollDistance = sourceMeasurements.scrollHeight - sourceMeasurements.clientHeight;
     }
 
     const position = resolvePx(value, sourceScrollDistance);

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -920,8 +920,8 @@ PASS	/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html	Anima
 PASS	/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html	Animation current time and effect local time are updated after scroller size changes.
 FAIL	/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html	If scroll animation resizes its scroll timeline scroller, layout reruns once per frame.
 PASS	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with percentage range [JavaScript API]
-FAIL	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with px range [JavaScript API]
-FAIL	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with calculated range [JavaScript API]
+PASS	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with px range [JavaScript API]
+PASS	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with calculated range [JavaScript API]
 FAIL	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with EM range [JavaScript API]
 FAIL	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with percentage range [CSS]
 FAIL	/scroll-animations/scroll-timelines/scroll-timeline-range.html	Scroll timeline with px range [CSS]


### PR DESCRIPTION
By accounting for the clientWidth/height we should pass two of the WAAPI tests in scroll-timeline-range.html.