### PR TITLE
Fix scroll-animation.html start and current time subtests

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -669,10 +669,6 @@ function tickAnimation(timelineTime) {
         (timelineTimeMs - fromCssNumberish(details, this.startTime)) *
             this.playbackRate);
 
-    // Conditionally reset the hold time so that the finished state can be
-    // properly recomputed.
-    if (playState == 'finished' && effectivePlaybackRate(details) != 0)
-      details.holdTime = null;
     updateFinishedState(details, false, false);
   }
 }
@@ -745,6 +741,12 @@ function createProxyEffect(details) {
       let timing = Object.assign({}, details.specifiedTiming);
 
       let totalDuration;
+
+      if (timing.duration === Infinity) {
+        throw TypeError(
+          "Effect duration cannot be Infinity when used with Scroll " +
+          "Timelines");
+      }
 
       // Duration 'auto' case.
       if (timing.duration === null || timing.duration === 'auto' || details.autoDurationEffect) {

--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -370,7 +370,9 @@ export function addAnimation(scrollTimeline, animation, tickAnimation) {
     animation: animation,
     tickAnimation: tickAnimation
   });
-  updateInternal(scrollTimeline);
+  queueMicrotask(() => {
+    updateInternal(scrollTimeline);
+  });
 }
 
 // TODO: this is a private function used for unit testing add function

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -912,8 +912,8 @@ PASS	/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline.html
 PASS	/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline.html	Animation start and current times are correct if scroll timeline is activated after animation.play call.
 PASS	/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline.html	Animation start and current times are correct if scroll timeline is activated after setting start time.
 PASS	/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline.html	Animation current time is correct when the timeline becomes newly inactive and then active again.
-FAIL	/scroll-animations/scroll-timelines/scroll-animation.html	Animation start and current times are correct for each animation state.
-FAIL	/scroll-animations/scroll-timelines/scroll-animation.html	Animation start and current times are correct for each animation state when the animation starts playing with advanced scroller.
+PASS	/scroll-animations/scroll-timelines/scroll-animation.html	Animation start and current times are correct for each animation state.
+PASS	/scroll-animations/scroll-timelines/scroll-animation.html	Animation start and current times are correct for each animation state when the animation starts playing with advanced scroller.
 PASS	/scroll-animations/scroll-timelines/scroll-animation.html	Finished animation plays on reverse scrolling.
 FAIL	/scroll-animations/scroll-timelines/scroll-animation.html	Sending animation finished events by finished animation on reverse scrolling.
 PASS	/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html	Animation current time and effect local time are updated after scroller content size changes.
@@ -960,7 +960,7 @@ PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting an unre
 PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting an unresolved start time sets the hold time to unresolved when the timeline is inactive
 PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting the start time resolves a pending ready promise
 PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting the start time resolves a pending ready promise when the timelineis inactive
-FAIL	/scroll-animations/scroll-timelines/setting-start-time.html	Setting an unresolved start time on a play-pending animation makes it idle
+PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting an unresolved start time on a play-pending animation makes it idle
 PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting the start time updates the finished state
 PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting the start time on a running animation updates the play state
 PASS	/scroll-animations/scroll-timelines/setting-start-time.html	Setting the start time on a reverse running animation updates the play state


### PR DESCRIPTION
Schedule a micro task for `updatingInternal()` after adding an animation. If `updateInternal()` runs in the same task then `animation.currentTime` will be set by the time animation.play() returns.

Delaying this function revealed two other issues that needed to be fixed: 
- Infinite durations needed to be validated in getTimingHandler.
- holdTime was set to unresolved in tickAnimation, flipping the playState from 'finished' to 'running'. 