### PR TITLE
Print out error when failing to calculate the rangeStart and rangeEnd

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -889,7 +889,7 @@ function autoAlignStartTime(details) {
   //    In the case of view timelines, it requires a calculation based on the proportion of the cover range.
   try {
     startOffset = CSS.percent(fractionalStartDelay(details) * 100);
-  } catch {
+  } catch (e) {
     // TODO: Validate supported values for range start, to avoid exceptions when resolving the values.
 
     // Range start is invalid, falling back to default value
@@ -902,7 +902,7 @@ function autoAlignStartTime(details) {
   //    In the case of view timelines, it requires a calculation based on the proportion of the cover range.
   try {
     endOffset = CSS.percent((1 - fractionalEndDelay(details)) * 100);
-  } catch {
+  } catch (e) {
     // TODO: Validate supported values for range end, to avoid exceptions when resolving the values.
 
     // Range start is invalid, falling back to default value


### PR DESCRIPTION
Super small bugfixes. I was trying to run the example on the README in my npm'ish branch and there's some other issues (ie: divide by zero exception), but I couldn't see those as the `console.warn` didn't have the error in scope. This PR just adds `catch (e)` to 2 places so we can do `console.warn('<message>', e)`.