### PR TITLE
Fix regression due to handling of normal range

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -959,13 +959,16 @@ function getNormalEndRange(timeline) {
 }
 
 function parseAnimationRange(timeline, value) {
-  const animationRange = {
-    start: 'normal',
-    end: 'normal',
-  };
-
   if (!value)
-    return animationRange;
+    return {
+      start: 'normal',
+      end: 'normal',
+    };
+
+  const animationRange = {
+    start: getNormalStartRange(timeline),
+    end: getNormalEndRange(timeline),
+  };
 
   if (timeline instanceof ViewTimeline) {
     // Format:


### PR DESCRIPTION
Fix regression due to https://github.com/flackr/scroll-timeline/pull/223

We should return `normal` as the default  range start and end, but the parsing still expects a TimelineRangeOffset which can cause an issue.

Fixing the issue by only returning `normal` when no range was set by the user, keeping the TimelineRangeOffset from getNormalStart/EndRange otherwise.

There's already a todo to handle the full syntax later.