### PR TITLE
Force parsing the linked stylesheet before animation starts

### DIFF
--- a/demo/scroll-timeline-external-css/index.html
+++ b/demo/scroll-timeline-external-css/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../../dist/scroll-timeline.js"></script>
+
+<link rel="stylesheet" href="styles.css">
+<body>  
+  <div id=container>
+    <div id=progress></div>
+    <div class="spacer"></div>
+    <div class="spacer"></div>
+    <div class="spacer"></div>
+  </div>
+</body>
+

--- a/demo/scroll-timeline-external-css/styles.css
+++ b/demo/scroll-timeline-external-css/styles.css
@@ -1,0 +1,33 @@
+#container {
+  scroll-timeline-name: --foo, --bar;
+  overflow: scroll;
+  width: 500px;
+  height: 500px;
+  border: 1px solid #333;
+}
+
+.spacer {
+  width: 100%;
+  height: 500px;
+}
+
+#progress {
+  position: fixed;
+  height: 10px;
+  background-color: red;
+  animation: 1s progress linear forwards;
+  animation-timeline: --foo;
+}
+
+body {
+  margin: 0px;
+}
+
+@keyframes progress {
+  from {
+    width: 0px;
+  }
+  to {
+    width: 500px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
         <a href="demo/view-timeline-external-css/">demo/view-timeline-external-css</a>
     </li>
     <li>
+        <a href="demo/scroll-timeline-external-css/">demo/scroll-timeline-external-css</a>
+    </li>
+    <li>
         <a href="demo/basic/anonymous-scroll-timeline.html">demo/basic/anonymous-scroll-timeline.html</a>
     </li>
     <li>

--- a/src/scroll-timeline-css.js
+++ b/src/scroll-timeline-css.js
@@ -53,7 +53,14 @@ function initMutationObserver() {
       // Most likely we won't be able to fetch resources from other origins.
       return;
     }
-    fetch(linkElement.getAttribute('href')).then(async (response) => {
+
+    // Stop loading the stylesheet to ensure that we finished parsing it before it's
+    // loaded by the browser (and that animations are only started after
+    // we collected the required options)
+    const href = linkElement.getAttribute('href')
+    linkElement.removeAttribute('href')
+
+    fetch(href).then(async (response) => {
       const result = await response.text();
       let newSrc = parser.transpileStyleSheet(result, true);
       newSrc = parser.transpileStyleSheet(result, false);
@@ -61,6 +68,8 @@ function initMutationObserver() {
         const blob = new Blob([newSrc], { type: 'text/css' });
         const url = URL.createObjectURL(blob);
         linkElement.setAttribute('href', url);
+      } else {
+        linkElement.setAttribute('href', href);
       }
     });
   }


### PR DESCRIPTION
There is a chance for the animation to start before the polyfill parses the linked stylesheet because we download and parse it at the same time than the browser.

When this happens, the ScrollTimeline is not created because the associated options are not available yet (
getAnimationTimelineOptions return null).

To prevent this from happening we remove the href of the linked stylesheet to ensure that the polyfill will process the stylesheet before the browser.