### PR TITLE
Update README.md with helpful note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Also works with CSS Animations that use a `view-timeline` or `scroll-timeline`
 }
 ```
 
+Please ensure your CSS is hosted on the same domain as your website or included directly on the page within a <style> tag.
+
+If you are loading stylesheets from other origins, the polyfill might not be able to fetch and apply them correctly, due to browser security restrictions.
+
 For more details on and use-cases of scroll-driven animations, please refer to [https://developer.chrome.com/articles/scroll-driven-animations/](https://developer.chrome.com/articles/scroll-driven-animations/) and [https://scroll-driven-animations.style/](https://scroll-driven-animations.style/)
 
 # Contributing


### PR DESCRIPTION
I couldn't figure out why the polyfill wasn't working for me until I checked the actual code of the polyfill and saw that it doesn't work with css from other origins, so I think adding a note explaining this in the readme is pretty important.

Here's [the part of the polyfill](https://github.com/flackr/scroll-timeline/blob/702b716afa35bd2b948a4b208ed552db2472de8e/src/scroll-timeline-css.js#L51) I'm referring to:
```javascript
const url = new URL(linkElement.href, document.baseURI);
if (url.origin !== location.origin) {
  // Most likely we won't be able to fetch resources from other origins.
  return;
}
``` 