### PR TITLE
Proxy commitStyles

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -1817,6 +1817,10 @@ export class ProxyAnimation {
     proxyAnimations.get(this).animation.persist();
   }
 
+  commitStyles() {
+    proxyAnimations.get(this).animation.commitStyles();
+  }
+
   get id() {
     return proxyAnimations.get(this).animation.id;
   }


### PR DESCRIPTION
The `commitStyles` method is missing from ProxyAnimation