### PR TITLE
Handle double precision in playState

### DIFF
--- a/src/proxy-animation.js
+++ b/src/proxy-animation.js
@@ -1078,6 +1078,20 @@ function parseTimelineRangePart(timeline, value, position) {
   unsupportedTimeline(timeline);
 }
 
+function isGreaterOrEqual(a, b) {
+  if (Math.abs(a - b) <= 100000 * Number.EPSILON) {
+    return true;
+  }
+  return a > b;
+}
+
+function isLessOrEqual(a, b) {
+  if (Math.abs(a - b) <= 100000 * Number.EPSILON) {
+    return true;
+  }
+  return a < b;
+}
+
 // Create an alternate Animation class which proxies API requests.
 // TODO: Create a full-fledged proxy so missing methods are automatically
 // fetched from Animation.
@@ -1495,10 +1509,9 @@ export class ProxyAnimation {
     //     * animation’s effective playback rate < 0 and current time <= 0,
     //    then finished.
     if (currentTime != null) {
-      if (details.animation.playbackRate > 0 &&
-          currentTime >= effectEnd(details))
+      if (details.animation.playbackRate > 0 && isGreaterOrEqual(currentTime, effectEnd(details)))
         return 'finished';
-      if (details.animation.playbackRate < 0 && currentTime <= 0)
+      if (details.animation.playbackRate < 0 && isLessOrEqual(currentTime , 0))
         return 'finished';
     }
 

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -696,6 +696,7 @@ PASS	/scroll-animations/scroll-timelines/current-time-root-scroller.html	current
 PASS	/scroll-animations/scroll-timelines/current-time-writing-modes.html	currentTime handles direction: rtl correctly
 PASS	/scroll-animations/scroll-timelines/current-time-writing-modes.html	currentTime handles writing-mode: vertical-rl correctly
 PASS	/scroll-animations/scroll-timelines/current-time-writing-modes.html	currentTime handles writing-mode: vertical-lr correctly
+PASS	/scroll-animations/scroll-timelines/duration.html	The duration of a scroll timeline is 100%
 PASS	/scroll-animations/scroll-timelines/effect-updateTiming.html	Allows setting the delay to a positive number
 PASS	/scroll-animations/scroll-timelines/effect-updateTiming.html	Allows setting the delay to a negative number
 PASS	/scroll-animations/scroll-timelines/effect-updateTiming.html	Allows setting the delay of an animation in progress: positive delay that causes the animation to be no longer in-effect
@@ -1026,6 +1027,7 @@ PASS	/scroll-animations/view-timelines/block-view-timeline-current-time.tentativ
 FAIL	/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html	View timeline with subject that is not a direct descendant of the scroll container
 FAIL	/scroll-animations/view-timelines/change-animation-range-updates-play-state.html	Changing the animation range updates the play state
 FAIL	/scroll-animations/view-timelines/contain-alignment.html	Stability of animated elements aligned to the bounds of a contain region
+PASS	/scroll-animations/view-timelines/duration.html	The duration of a view timeline is 100%
 PASS	/scroll-animations/view-timelines/fieldset-source.html	Fieldset is a valid source for a view timeline
 FAIL	/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html	Report specified timeline offsets
 FAIL	/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html	Computed offsets can be outside [0,1] for keyframes with timeline offsets


### PR DESCRIPTION
Double precision errors can prevent `playState` from becoming "finished",
which in turn prevents the finished promise from resolving.

This is caused by precision loss due to floating point computations. For instance, converting an internal `holdTime` of 100000 to CSSNumberish and back can cause `currentTime` to become `99999.99999999999`. 

When the imprecise `currentTime` is compared against the `effectEnd()` with a regular `>=` operator the comparison will fail. This PR introduces an epsilon check to address this and ensure that the `playState` can become "finished".

