### PR TITLE
Fix: De-activate animation when scroll container has no overflow

### DIFF
--- a/src/scroll-timeline-base.js
+++ b/src/scroll-timeline-base.js
@@ -473,7 +473,7 @@ export class ScrollTimeline {
     const maxScrollPos = calculateMaxScrollOffset(container, axis);
 
     return maxScrollPos > 0 ? CSS.percent(100 * scrollPos / maxScrollPos)
-                            : CSS.percent(100);
+                            : unresolved;
   }
 
   get __polyfill() {
@@ -878,6 +878,10 @@ export class ViewTimeline extends ScrollTimeline {
     const offsets = range(this, 'cover');
     if (!offsets)
       return unresolved;
+    
+    if (offsets.end === offsets.start)
+      return unresolved;
+      
     const progress =
         (scrollPos - offsets.start) / (offsets.end - offsets.start);
 


### PR DESCRIPTION
## Problem

This polyfill applies scroll-driven animations even when the scroll container has no overflow (i.e., when `clientHeight === scrollHeight`). According to the specification ([source](https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress)):

> Progress (the current time) for a scroll progress timeline is calculated as: *scroll offset* ÷ (*scrollable overflow size* − *scroll container size*)
> 
> If the 0% position and 100% position coincide (i.e. the denominator in the current time formula is zero), the timeline is inactive.

When there is no overflow, then *scrollable overflow size* − *scroll container size* = 0. Currently, the timeline is set to 100% or `NaN` in these cases. Instead, it should be set to inactive.

## Changes

1. **`ScrollTimeline.currentTime`**: Return `unresolved` when `maxScrollPos <= 0`.
2. **`ViewTimeline.currentTime`**: Return `unresolved` when `offsets.end === offsets.start`.

**Note:** When the `currentTime` method returns `unresolved` (i.e., `null`), the `tickAnimation` function will cancel the animation. This ensures no effects are applied when the timeline is inactive.

**Note:** I think these changes also indirectly address the first issue raised in #298.